### PR TITLE
Remove deprecated permalink config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,3 @@
-# Permalinks
-#
-# Use of `relative_permalinks` ensures post links from the index work properly.
-permalink:           pretty
-relative_permalinks: true
-
 # Setup
 title:               OPEN DATA HANDBOOK
 tagline:             'California Health and Human Services Agency'


### PR DESCRIPTION
This should fix any page build failures. Relative permalinks was specified in this config file, but isn't necessary for this repo's file structure.
